### PR TITLE
ci: add a minimal devShell for CI builds

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -264,6 +264,29 @@
                   ln -sf ${mcp-config} .mcp.json
               '';
             };
+
+          # Minimal shell for CI builds: only what `deno task build` and
+          # `wrangler pages deploy` need, so CI doesn't pay for editor
+          # tooling (LSPs, textlint, claude-code, agent-browser, ...).
+          devShells.ci = pkgs.mkShell {
+            packages = with pkgs; [
+              vips
+              stdenv.cc.cc
+              deno
+              wrangler
+            ];
+
+            LD_LIBRARY_PATH = "${pkgs.lib.makeLibraryPath [ pkgs.stdenv.cc.cc ]}";
+
+            shellHook = ''
+              [ -e ./fonts ] && rm -r ./fonts
+              mkdir -p ./fonts/noto-fonts
+
+              ln -s ${fonts}/bin/NotoSansCJKjp-Regular.otf ./fonts/noto-fonts/NotoSansCJKjp-Regular.otf
+              ln -s ${fonts}/bin/NotoSansCJKjp-Bold.otf ./fonts/noto-fonts/NotoSansCJKjp-Bold.otf
+              ln -s ${fonts}/bin/NotoSansCJKjp-Black.otf ./fonts/noto-fonts/NotoSansCJKjp-Black.otf
+            '';
+          };
         };
     };
 }


### PR DESCRIPTION
## Summary
- CI(`deploy.yaml`)は現在 `nix develop`(デフォルトの devShell)経由でビルドしている
- デフォルトの devShell はローカル開発用のエディタLSP群(nil, lua-language-server, efm-langserver, tailwindcss-language-server, marksman)、textlint、claude-code、agent-browser、bun、git-secrets、unar、nushell などを含み、`deno task build` / `wrangler pages deploy` には不要なものが大半
- ビルドに実際必要な `deno` / `wrangler` / `vips` と、OG画像生成に使う noto-cjk フォントのsymlinkだけを持つ軽量な `devShells.ci` を追加した

## Note
- このPRには `flake.nix` の変更のみが含まれています。本来は `.github/workflows/deploy.yaml` の `nix develop` を `nix develop .#ci` に変更する差分もセットですが、このセッションのGitHub App権限に `workflows` がないため push できませんでした。マージ前に以下をご自身で反映してください:

```diff
-          nix develop --command deno task build
-          nix develop --command wrangler pages deploy ./_site --project-name=blog --commit-dirty=true
+          nix develop .#ci --command deno task build
+          nix develop .#ci --command wrangler pages deploy ./_site --project-name=blog --commit-dirty=true
```

## Test plan
- [ ] `nix develop .#ci --command deno task build` がローカル/CIで通ることを確認
- [ ] `nix develop .#ci --command wrangler pages deploy` が通ることを確認
- [ ] OG画像生成(フォント読み込み)が正しく動くことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XThpq2GnQzXBgwgsESiC6h

---
_Generated by [Claude Code](https://claude.ai/code/session_01XThpq2GnQzXBgwgsESiC6h)_