### PR TITLE
ci: make broken-link checking opt-in

### DIFF
--- a/_config.ts
+++ b/_config.ts
@@ -44,6 +44,11 @@ import footnote from "./plugins/lume/footnote.ts";
 
 const RELEASE = Deno.env.get("RELEASE");
 const DISABLE_LINKCARD = Deno.env.get("DISABLE_LINKCARD");
+// Broken-link checking walks every internal/external link on every post and
+// is slow (network I/O per link). It's opt-in so normal deploy builds don't
+// pay for it; run it explicitly (e.g. a scheduled/manual workflow) with
+// CHECK_URLS=1.
+const CHECK_URLS = Deno.env.get("CHECK_URLS");
 
 // Link card configuration interface
 interface LinkCardConfig {
@@ -112,9 +117,11 @@ if (RELEASE) {
   // site.use(brotli());
   // site.use(gzip());
 
-  site.use(checkUrls({
-    output: "_broken_links.json",
-  }));
+  if (CHECK_URLS) {
+    site.use(checkUrls({
+      output: "_broken_links.json",
+    }));
+  }
 
   site.use(favicon({
     input: "./public/favicon.svg",


### PR DESCRIPTION
## Summary
- `check_urls`(ブロークンリンクチェック)がRELEASEビルド(=通常のデプロイ)の度に全記事(450本超)の内部/外部リンクを検証しており、ネットワークI/O分だけデプロイの所要時間に乗っていた
- `CHECK_URLS` 環境変数によるオプトインに変更し、通常のデプロイビルドからは除外
- 必要な時は `CHECK_URLS=1 deno task build` のようにローカル実行、または将来的に別のスケジュール/手動ワークフローから明示的に有効化できる

## Test plan
- [ ] `deno task build`(`CHECK_URLS` 未設定)で `check_urls` が実行されず、`_broken_links.json` が生成されないことを確認
- [ ] `CHECK_URLS=1 deno task build` で従来通り `check_urls` が実行され `_broken_links.json` が生成されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XThpq2GnQzXBgwgsESiC6h

---
_Generated by [Claude Code](https://claude.ai/code/session_01XThpq2GnQzXBgwgsESiC6h)_